### PR TITLE
Create jwk-build and jwk-deploy OpenShift template

### DIFF
--- a/openshift/jwks/README.md
+++ b/openshift/jwks/README.md
@@ -1,3 +1,5 @@
+# JWKS Readme
+
  This is a build of a really simple nginx docker container which provides a jwks.json file from a URL for JWT encryption purposes
 
  You can build it using docker or docker compose
@@ -37,4 +39,22 @@
 ```
 The only value which can be changed is the "n" property which is the public key obtained from demojwks.cert.pem , converted from the PEM format in this file to the JWKS modulo format using an online tool eg. https://8gwifi.org/jwkconvertfunctions.jsp
 
+## OpenShift
+
+## Setting up builds and deployments
+
+1. Upload `jwk-build.yaml` to the `tools` environment
+2. Upload `jwk-deploy.yaml` to the dev/test/prod/whatever environment.  Currently we only are deploying to test.
+
+Make sure you update the environment variables as appropriate to each environment.
+
  
+## Deploying a build
+
+Deploying the latest JWKS code is simple.  We do not use a Jenkins pipeline here.
+
+1. Login to OpenShift and navigate to the  "tools" project
+2. Builds > Builds, then select `jwks-build-test`
+3. Click 'Start Build' in the top right.
+
+This will trigger a build, which takes ~2-5 minutes, and then after that a deployment in the TEST environment (another 1-2 mins).  Then the deployment should be complete and the changes should be updated at `https://services-card-jwks-demo.pathfinder.gov.bc.ca/`

--- a/openshift/jwks/jwk-build.yaml
+++ b/openshift/jwks/jwk-build.yaml
@@ -1,0 +1,57 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: "${API_NAME}-build-template"
+  creationTimestamp: 
+objects:
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    name: "${API_NAME}-${TAG_NAME}"
+- kind: BuildConfig
+  apiVersion: v1
+  metadata:
+    name: "${API_NAME}-build-${TAG_NAME}"
+    labels:
+      app: "${API_NAME}-build-${TAG_NAME}"
+  spec:
+    runPolicy: Serial
+    source:
+      type: Git
+      git:
+        uri: "${GIT_REPO_URL}"
+        ref: "${GIT_REF}"
+      contextDir: "${SOURCE_CONTEXT_DIR}"
+    strategy:
+      type: Docker
+    output:
+      to:
+        kind: ImageStreamTag
+        name: "${API_NAME}-${TAG_NAME}:latest"
+parameters:
+- name: API_NAME
+  displayName: Name
+  description: The name assigned to all of the resources defined in this template.
+  required: true
+  value: jwks
+- name: GIT_REPO_URL
+  displayName: Git Repo URL
+  description: The URL to your GIT repo.
+  required: true
+  value: https://github.com/bcgov/BCSC-SS.git
+- name: GIT_REF
+  displayName: Git Reference
+  description: The git reference or branch.
+  required: true
+  value: dev 
+- name: SOURCE_CONTEXT_DIR
+  displayName: Source Context Directory
+  description: The source context directory.
+  required: false
+  value: openshift/jwks
+- name: TAG_NAME
+  displayName: Environment Name
+  description: The name of the environment you ultimately wish to deploy to (dev, test, prod)
+  required: true
+  value: test

--- a/openshift/jwks/jwk-deploy.yaml
+++ b/openshift/jwks/jwk-deploy.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  annotations:
+    description: Deployment template for jwks
+    tags: npm
+  name: jwks
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: 
+    labels:
+      app: "${NAME}"
+    name: "${NAME}"
+  spec:
+    replicas: 1
+    selector:
+      app: "${NAME}"
+      deploymentconfig: "${NAME}"
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        creationTimestamp: 
+        labels:
+          app: "${NAME}"
+          deploymentconfig: "${NAME}"
+      spec:
+        containers:
+        - image: "${SOURCE_NAME}"
+          imagePullPolicy: Always
+          name: "${NAME}"
+          ports:
+          - containerPort: 8081
+            protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 250m
+              memory: 200Mi
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+        - "${NAME}"
+        from:
+          kind: ImageStreamTag
+          namespace: "${IMAGE_NAMESPACE}"
+          name: "${SOURCE_NAME}-${TAG_NAME}:latest"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: 
+    labels:
+      app: "${NAME}"
+    name: "${NAME}"
+  spec:
+    ports:
+    - name: 8081-tcp
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+    selector:
+      app: "${NAME}"
+      deploymentconfig: "${NAME}"
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: "${NAME}"
+    name: "${NAME}"
+  spec:
+    host: "${HOSTNAME}"
+    port:
+      targetPort: 8081-tcp
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      terminationc: edge
+    to:
+      kind: Service
+      name: "${NAME}"
+      weight: 100
+parameters:
+- description: The name of the source image
+  displayName: Source Name
+  name: SOURCE_NAME
+  required: true
+  value: jwks
+- description: The name assigned to all of the openshift objects defined in this template.
+    It is also the name of runtime image you want.
+  displayName: Name
+  name: NAME
+  required: true
+  value: jwks
+- description: The namespace where to get the above image name
+  displayName: Image Namespace
+  name: IMAGE_NAMESPACE
+  required: true
+  value: oultzp-tools
+- description: The TAG name for this environment, e.g., dev, test, prod
+  displayName: Env TAG name
+  name: TAG_NAME
+  value: test
+- description: The public URL to access this deployment (incldue `pathfinder.gov.bc.ca`)
+  displayName: Env TAG name
+  name: HOSTNAME
+  value: services-card-jwks-demo.pathfinder.gov.bc.ca


### PR DESCRIPTION
As of this commit these have already been setup and deployed in tools and test environment.  

The templates are working, and if the service is ever destroyed or needs to be deployed in a new environment it should be pretty straightforward.